### PR TITLE
禁用DataBinding插件，添加Espresso Test Recorder示例

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,7 @@ android {
 
         // 支持SVG
         vectorDrawables.useSupportLibrary = true
+        testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -23,7 +24,7 @@ android {
 
     // 打开DataBinding
     dataBinding {
-        enabled = true
+        enabled = false
     }
 }
 
@@ -42,4 +43,13 @@ dependencies {
     compile 'io.reactivex:rxjava:1.1.6'
     compile 'io.reactivex:rxandroid:1.2.1'
     compile 'com.google.dagger:dagger:2.5'
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+    }
+    androidTestCompile 'com.android.support.test.espresso:espresso-contrib:2.2.2', {
+        exclude group: 'com.android.support', module: 'support-annotations'
+        exclude group: 'com.android.support', module: 'support-v4'
+        exclude group: 'com.android.support', module: 'design'
+        exclude group: 'com.android.support', module: 'recyclerview-v7'
+    }
 }

--- a/app/src/androidTest/java/com/kibey/android/demo/espresso/EspressoActivityTest.java
+++ b/app/src/androidTest/java/com/kibey/android/demo/espresso/EspressoActivityTest.java
@@ -1,0 +1,110 @@
+package com.kibey.android.demo.espresso;
+
+
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.espresso.matcher.ViewMatchers;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import com.kibey.android.demo.MainActivity;
+import com.kibey.android.demo.R;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.contrib.RecyclerViewActions.actionOnItemAtPosition;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+import static android.support.test.espresso.matcher.ViewMatchers.withParent;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.allOf;
+
+/**
+ * 这个类的所有代码,当然除了这里的注释全部都是Espresso Test Recorder自动创建的。
+ * 当前录制的操作是新增五条内容,删除第3和第4条内容。
+ * 详细参考:
+ * <a href="https://developer.android.com/studio/test/espresso-test-recorder.html">https://developer.android.com/studio/test/espresso-test-recorder.html</a>
+ */
+@LargeTest
+@RunWith(AndroidJUnit4.class)
+public class EspressoActivityTest {
+
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);
+
+    @Test
+    public void espressoActivityTest() {
+        ViewInteraction recyclerView = onView(
+                allOf(ViewMatchers.withId(R.id.content_rv), isDisplayed()));
+        recyclerView.perform(actionOnItemAtPosition(0, click()));
+
+        ViewInteraction appCompatButton = onView(
+                allOf(withText("新增"),
+                        withParent(allOf(withId(R.id.action_container),
+                                withParent(withId(R.id.activity_espresso)))),
+                        isDisplayed()));
+        appCompatButton.perform(click());
+
+        ViewInteraction appCompatButton2 = onView(
+                allOf(withText("新增"),
+                        withParent(allOf(withId(R.id.action_container),
+                                withParent(withId(R.id.activity_espresso)))),
+                        isDisplayed()));
+        appCompatButton2.perform(click());
+
+        ViewInteraction appCompatButton3 = onView(
+                allOf(withText("新增"),
+                        withParent(allOf(withId(R.id.action_container),
+                                withParent(withId(R.id.activity_espresso)))),
+                        isDisplayed()));
+        appCompatButton3.perform(click());
+
+        ViewInteraction appCompatButton4 = onView(
+                allOf(withText("新增"),
+                        withParent(allOf(withId(R.id.action_container),
+                                withParent(withId(R.id.activity_espresso)))),
+                        isDisplayed()));
+        appCompatButton4.perform(click());
+
+        ViewInteraction appCompatButton5 = onView(
+                allOf(withText("新增"),
+                        withParent(allOf(withId(R.id.action_container),
+                                withParent(withId(R.id.activity_espresso)))),
+                        isDisplayed()));
+        appCompatButton5.perform(click());
+
+        ViewInteraction appCompatButton6 = onView(
+                allOf(withText("新增"),
+                        withParent(allOf(withId(R.id.action_container),
+                                withParent(withId(R.id.activity_espresso)))),
+                        isDisplayed()));
+        appCompatButton6.perform(click());
+
+        ViewInteraction appCompatCheckBox = onView(
+                allOf(withId(R.id.item_espresso), withText("新增内容3"),
+                        withParent(allOf(withId(R.id.item_container),
+                                withParent(withId(R.id.activity_espresso)))),
+                        isDisplayed()));
+        appCompatCheckBox.perform(click());
+
+        ViewInteraction appCompatCheckBox2 = onView(
+                allOf(withId(R.id.item_espresso), withText("新增内容4"),
+                        withParent(allOf(withId(R.id.item_container),
+                                withParent(withId(R.id.activity_espresso)))),
+                        isDisplayed()));
+        appCompatCheckBox2.perform(click());
+
+        ViewInteraction appCompatButton7 = onView(
+                allOf(withText("删除"),
+                        withParent(allOf(withId(R.id.action_container),
+                                withParent(withId(R.id.activity_espresso)))),
+                        isDisplayed()));
+        appCompatButton7.perform(click());
+
+    }
+
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
             </intent-filter>
         </activity>
         <activity android:name=".sample.SampleActivity"/>
+        <activity android:name=".espresso.EspressoActivity">
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/kibey/android/demo/espresso/EspressoActivity.java
+++ b/app/src/main/java/com/kibey/android/demo/espresso/EspressoActivity.java
@@ -1,0 +1,72 @@
+package com.kibey.android.demo.espresso;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.CheckBox;
+import android.widget.LinearLayout;
+
+import com.kibey.android.demo.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * EspressoActivity
+ * AndroidStudio2.2新加入的功能EspressoTestRecorder
+ * 详细参考:
+ * <a href="https://developer.android.com/studio/test/espresso-test-recorder.html">https://developer.android.com/studio/test/espresso-test-recorder.html</a>
+ *
+ * @author xl
+ * @version V1.0
+ * @see <a href="https://developer.android.com/studio/test/espresso-test-recorder.html">espresso-test-recorder</a>
+ * @since 16/9/19
+ */
+public class EspressoActivity extends AppCompatActivity {
+
+    private LinearLayout mItemContainer;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_espresso);
+        mItemContainer = (LinearLayout) findViewById(R.id.item_container);
+    }
+
+    private int mIndex = 0;
+
+    public void addItem(View view) {
+        View itemView = createItemView("新增内容" + mIndex++);
+        mItemContainer.addView(itemView);
+    }
+
+    public void delItem(View view) {
+        List<View> needRemove = new ArrayList<>();
+        for (int i = 0, size = mItemContainer.getChildCount(); i < size; i++) {
+            View v = mItemContainer.getChildAt(i);
+            if (v instanceof CheckBox) {
+                if (((CheckBox) v).isChecked()) {
+                    needRemove.add(v);
+                }
+            }
+        }
+
+        for (View remove : needRemove) {
+            mItemContainer.removeView(remove);
+        }
+    }
+
+    private View createItemView(String item) {
+        return createItemView(item, mItemContainer);
+    }
+
+    private View createItemView(String item, ViewGroup parent) {
+        View view = LayoutInflater.from(this).inflate(R.layout.item_espresso, parent, false);
+        if (view instanceof CheckBox) {
+            ((CheckBox) view).setText(item);
+        }
+        return view;
+    }
+}

--- a/app/src/main/res/layout/activity_espresso.xml
+++ b/app/src/main/res/layout/activity_espresso.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_espresso"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin"
+    tools:context="com.kibey.android.demo.espresso.EspressoActivity">
+
+    <LinearLayout
+        android:id="@+id/action_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="addItem"
+            android:text="@string/espresso_add"/>
+
+        <Button
+            style="?android:attr/buttonBarButtonStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="delItem"
+            android:text="@string/espresso_del"/>
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/item_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/action_container"
+        android:orientation="vertical"/>
+
+</RelativeLayout>

--- a/app/src/main/res/layout/item_espresso.xml
+++ b/app/src/main/res/layout/item_espresso.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<CheckBox
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/item_espresso"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="Espresso"
+    android:textAppearance="@android:style/TextAppearance.Medium"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,12 @@
 <resources>
     <string name="app_name">AndroidDemo</string>
     <string name="sample_activity_content">示例Activity,添加Activity可以参考这个界面</string>
+
+    <string name="lib_request_permission_title">权限请求</string>
+    <string name="lib_dialog_ok">确定</string>
+    <string name="lib_request_contacts_title">请求通讯录</string>
+    <string name="lib_request_camera_title">请求摄像头</string>
+    <string name="lib_request_location_title">请求位置</string>
+    <string name="espresso_add">新增</string>
+    <string name="espresso_del">删除</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
1、禁用DataBinding，因为DataBinding跟AndroidStudio2.2之间有兼容问题，开启DataBinding在AndroidStudio2.2上项目代码文件夹会显示成全类名，当前项目也没有使用DataBinding，所以先禁用DataBinding插件了。
2、更新gradel到2.2。
3、添加Espresso Test Recorder示例Demo。项目里直接右键androidTest下的com.kibey.android.demo.espresso.EspressoActivityTest点击Run EspressoActivityTest 就可以看到效果。
